### PR TITLE
Update pre-commit hooks: poetry and flake8

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ default_language_version:
   python: python3.9
 repos:
   - repo: https://github.com/python-poetry/poetry
-    rev: '1.2.0rc1'  # add version here
+    rev: '1.2.1'  # add version here
     hooks:
       - id: poetry-check
       - id: poetry-lock
@@ -73,7 +73,7 @@ repos:
           - flake8-print==4.0.0
           # - flake8-fastapi==0.6.1
           - flake8-keyword-arguments==0.1.0
-          - flake8-async==22.3.10
+          # - flake8-async==22.3.10  # not compatible with flake8 ^5.0
           - pep8-naming==0.13.0
 
   - repo: https://github.com/asottile/yesqa


### PR DESCRIPTION
1. Unfortunately "pre-commit autoupdate" cannot handle poetry's latest version
2. flake8-async dependency is not compatible with flake8 ^5.0